### PR TITLE
Implement skeleton for server

### DIFF
--- a/src/objects/BodyLogin.java
+++ b/src/objects/BodyLogin.java
@@ -1,0 +1,28 @@
+package objects;
+
+import java.io.Serializable;
+
+public class BodyLogin implements Serializable {
+    private String uniName;
+    private String loginID;
+    private String password;
+
+    public BodyLogin(String uniName, String loginID, String password) {
+        this.uniName = uniName;
+        this.loginID = loginID;
+        this.password = password;
+    }
+
+    public String getUniName() {
+        return uniName;
+    }
+
+    public String getLoginID() {
+        return loginID;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+}

--- a/src/objects/ClientMsg.java
+++ b/src/objects/ClientMsg.java
@@ -26,4 +26,12 @@ public class ClientMsg implements Serializable {
     public boolean isEndpoint(String method, String resource) {
         return this.method.equals(method) && this.resource.equals(resource);
     }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getResource() {
+        return resource;
+    }
 }

--- a/src/objects/ClientMsg.java
+++ b/src/objects/ClientMsg.java
@@ -5,6 +5,8 @@ import java.io.Serializable;
 public class ClientMsg implements Serializable {
     private final String method;
     private final String resource;
+    // It's possible to maybe remove this field
+    // since the server knows who it's talking to anyway.
     private String authorID;
     private Serializable body;
 

--- a/src/objects/ScheduleEntry.java
+++ b/src/objects/ScheduleEntry.java
@@ -25,11 +25,8 @@ public class ScheduleEntry implements Serializable {
         this.end_time = end_time;
     }
 
-    public OffsetTime[] getTime() {
-        OffsetTime[] temp = new OffsetTime[2];
-        temp[0] = start_time;
-        temp[1] = end_time;
-        return temp;
+    public Tuple getTime() {
+        return new Tuple(start_time, end_time);
     }
 
     public String getLocation() {

--- a/src/objects/Tuple.java
+++ b/src/objects/Tuple.java
@@ -1,0 +1,22 @@
+package objects;
+
+import java.time.OffsetTime;
+
+public class Tuple {
+    private final OffsetTime start;
+    private final OffsetTime end;
+
+    public Tuple(OffsetTime start, OffsetTime end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public OffsetTime getStart() {
+        return start;
+    }
+
+    public OffsetTime getEnd() {
+        return end;
+    }
+
+}

--- a/src/server/AdminSessionHandler.java
+++ b/src/server/AdminSessionHandler.java
@@ -1,0 +1,139 @@
+package server;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.Socket;
+
+import objects.Administrator;
+import objects.ClientMsg;
+import objects.ServerMsg;
+import objects.University;
+
+public class AdminSessionHandler extends SessionHandler {
+    private Administrator admin;
+
+    public AdminSessionHandler(Socket socket, ObjectInputStream istream, ObjectOutputStream ostream,
+            University university, Administrator admin) {
+        super(socket, istream, ostream, university);
+        this.admin = admin;
+    }
+
+    @Override
+    public void run() {
+        try {
+            // NOTE: Temporary, may return some more info like admin name and stuff.
+            // Probably will just send the entire Admin object tbh but will see how it goes.
+            ostream.writeObject(ServerMsg.asOK(admin.getID()));
+            while (true) {
+                ClientMsg req = null;
+                ServerMsg resp = null;
+
+                try {
+                    req = (ClientMsg) istream.readObject();
+                } catch (ClassNotFoundException err) {
+                    ostream.writeObject(ServerMsg.asERR("Conversion failed, 'ClientMsg' expected."));
+                    continue;
+                }
+
+                if (req.isEndpoint("CREATE", "logout")) {
+                    resp = logout(req);
+                    ostream.writeObject(resp);
+                    // Just in case it fails to logout somehow.
+                    if (resp.isOk()) {
+                        break;
+                    }
+                }
+
+                if (req.isEndpoint("CREATE", "message")) {
+                    resp = capitalizeMessage(req);
+                } else if (req.isEndpoint("GET", "courses")) {
+                    resp = fetchCourses(req);
+                } else if (req.isEndpoint("GET", "report")) {
+                    resp = fetchReport(req);
+                } else if (req.isEndpoint("CREATE", "student")) {
+                    resp = createStudent(req);
+                } else if (req.isEndpoint("CREATE", "section")) {
+                    resp = addSection(req);
+                } else if (req.isEndpoint("EDIT", "section")) {
+                    resp = editSection(req);
+                } else if (req.isEndpoint("DELETE", "section")) {
+                    resp = delSection(req);
+                } else if (req.isEndpoint("CREATE", "course")) {
+                    resp = addCourse(req);
+                } else if (req.isEndpoint("EDIT", "course")) {
+                    resp = editCourse(req);
+                } else if (req.isEndpoint("DELETE", "course")) {
+                    resp = delCourse(req);
+                } else if (req.isEndpoint("CREATE", "enroll-student")) {
+                    resp = enrollStudent(req);
+                } else if (req.isEndpoint("CREATE", "drop-student")) {
+                    resp = dropStudent(req);
+                }
+
+                if (resp != null) {
+                    ostream.writeObject(resp);
+                } else {
+                    ostream.writeObject(ServerMsg.asERR(
+                            String.format("Endpoint '%s %s' is not available.", req.getMethod(), req.getResource())));
+                }
+            }
+        } catch (IOException err) {
+            err.printStackTrace();
+        }
+    }
+
+    // NOTE: Mock service, will delete later.
+    private ServerMsg capitalizeMessage(ClientMsg req) {
+        String message = (String) req.getBody();
+        return ServerMsg.asOK(message.toUpperCase());
+    }
+
+    private ServerMsg logout(ClientMsg req) {
+        return ServerMsg.asOK("logout");
+    }
+
+    private ServerMsg fetchCourses(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg fetchReport(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg createStudent(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg addSection(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg editSection(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg delSection(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg addCourse(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg editCourse(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg delCourse(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg enrollStudent(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg dropStudent(ClientMsg req) {
+        return null;
+    }
+}

--- a/src/server/ClientHandler.java
+++ b/src/server/ClientHandler.java
@@ -10,12 +10,15 @@ import java.net.Socket;
 import objects.Account;
 import objects.ClientMsg;
 import objects.ServerMsg;
+import objects.University;
 
 public class ClientHandler implements Runnable {
     final private Socket socket;
+    final private University[] universities;
 
-    public ClientHandler(Socket socket) {
+    public ClientHandler(Socket socket, University[] universities) {
         this.socket = socket;
+        this.universities = universities;
     }
 
     @Override
@@ -24,6 +27,15 @@ public class ClientHandler implements Runnable {
                 OutputStream raw_ostream = socket.getOutputStream()) {
             ObjectOutputStream ostream = new ObjectOutputStream(raw_ostream);
             try {
+                // NOTE: Whether or not the client initiate the request
+                // or the server automatically send this info, need more
+                // discussion with whoever is maintaining the client code.
+                String[] uniNames = new String[universities.length];
+                for (int i = 0; i < uniNames.length; ++i) {
+                    uniNames[i] = universities[i].getName();
+                }
+                ostream.writeObject(ServerMsg.asOK(uniNames));
+
                 ObjectInputStream istream = new ObjectInputStream(raw_istream);
                 ClientMsg req = (ClientMsg) istream.readObject();
                 if (req.isEndpoint("GET", "foo")) {

--- a/src/server/ClientHandler.java
+++ b/src/server/ClientHandler.java
@@ -8,6 +8,7 @@ import java.io.OutputStream;
 import java.net.Socket;
 
 import objects.Account;
+import objects.BodyLogin;
 import objects.ClientMsg;
 import objects.ServerMsg;
 import objects.University;
@@ -27,21 +28,67 @@ public class ClientHandler implements Runnable {
                 OutputStream raw_ostream = socket.getOutputStream()) {
             ObjectOutputStream ostream = new ObjectOutputStream(raw_ostream);
             try {
-                // NOTE: Whether or not the client initiate the request
-                // or the server automatically send this info, need more
-                // discussion with whoever is maintaining the client code.
-                String[] uniNames = new String[universities.length];
-                for (int i = 0; i < uniNames.length; ++i) {
-                    uniNames[i] = universities[i].getName();
-                }
-                ostream.writeObject(ServerMsg.asOK(uniNames));
-
+                boolean isSessionExist = false;
                 ObjectInputStream istream = new ObjectInputStream(raw_istream);
-                ClientMsg req = (ClientMsg) istream.readObject();
-                if (req.isEndpoint("GET", "foo")) {
-                    ostream.writeObject(ServerMsg.asOK("bar"));
-                } else {
-                    ostream.writeObject(ServerMsg.asERR("baz"));
+
+                // Loop until the socket itself closes (gracefully or abruptly).
+                while (true) {
+                    isSessionExist = false;
+
+                    // NOTE: Whether or not the client initiate the request
+                    // or the server automatically send this info, need more
+                    // discussion with whoever is maintaining the client code.
+                    String[] uniNames = new String[universities.length];
+                    for (int i = 0; i < uniNames.length; ++i) {
+                        uniNames[i] = universities[i].getName();
+                    }
+                    ostream.writeObject(ServerMsg.asOK(uniNames));
+                    var req = (ClientMsg) istream.readObject();
+                    if (!req.isEndpoint("CREATE", "login")) {
+                        ostream.writeObject(ServerMsg.asERR(String.format("'CREATE login' expected, received '%s %s'",
+                                req.getMethod(), req.getResource())));
+                        continue;
+                    }
+
+                    var body = (BodyLogin) req.getBody();
+                    for (var uni : universities) {
+                        if (uni.getName().equals(body.getUniName())) {
+                            for (var student : uni.getStudents().values()) {
+                                Account acc = student.getAccount();
+                                if (acc.verify(body.getLoginID(), body.getPassword())) {
+                                    isSessionExist = true;
+                                    // Start session.
+                                    break;
+                                }
+                            }
+                            if (!isSessionExist) {
+                                for (var instructor : uni.getInstructors().values()) {
+                                    Account acc = instructor.getAccount();
+                                    // Instructor may not have account.
+                                    if (acc != null && acc.verify(body.getLoginID(), body.getPassword())) {
+                                        isSessionExist = true;
+                                        // Start session.
+                                        break;
+                                    }
+                                }
+                            }
+                            if (!isSessionExist) {
+                                for (var admin : uni.getAdmins()) {
+                                    Account acc = admin.getAccount();
+                                    if (acc.verify(body.getLoginID(), body.getPassword())) {
+                                        isSessionExist = true;
+                                        new AdminSessionHandler(socket, istream, ostream, uni, admin).run();
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (!isSessionExist) {
+                        ostream.writeObject(ServerMsg.asERR(String.format("Incorrect credential for entity (%s @ %s).",
+                                body.getLoginID(), body.getUniName())));
+                    }
                 }
             } catch (ClassNotFoundException err) {
                 System.err.println("Casting failed.");

--- a/src/server/ClientHandler.java
+++ b/src/server/ClientHandler.java
@@ -57,7 +57,7 @@ public class ClientHandler implements Runnable {
                                 Account acc = student.getAccount();
                                 if (acc.verify(body.getLoginID(), body.getPassword())) {
                                     isSessionExist = true;
-                                    // Start session.
+                                    new StudentSessionHandler(socket, istream, ostream, uni, student).run();
                                     break;
                                 }
                             }
@@ -67,7 +67,7 @@ public class ClientHandler implements Runnable {
                                     // Instructor may not have account.
                                     if (acc != null && acc.verify(body.getLoginID(), body.getPassword())) {
                                         isSessionExist = true;
-                                        // Start session.
+                                        new InstructorSessionHandler(socket, istream, ostream, uni, instructor).run();
                                         break;
                                     }
                                 }

--- a/src/server/InstructorSessionHandler.java
+++ b/src/server/InstructorSessionHandler.java
@@ -1,0 +1,69 @@
+package server;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.Socket;
+
+import objects.ClientMsg;
+import objects.Instructor;
+import objects.ServerMsg;
+import objects.University;
+
+public class InstructorSessionHandler extends SessionHandler {
+    private Instructor instructor;
+
+    public InstructorSessionHandler(Socket socket, ObjectInputStream istream, ObjectOutputStream ostream,
+            University university, Instructor instructor) {
+        super(socket, istream, ostream, university);
+        this.instructor = instructor;
+    }
+
+    @Override
+    public void run() {
+        try {
+            ostream.writeObject(ServerMsg.asOK(instructor.getID()));
+            while (true) {
+                ClientMsg req = null;
+                ServerMsg resp = null;
+
+                try {
+                    req = (ClientMsg) istream.readObject();
+                } catch (ClassNotFoundException err) {
+                    ostream.writeObject(ServerMsg.asERR("Conversion failed, 'ClientMsg' expected."));
+                    continue;
+                }
+
+                if (req.isEndpoint("CREATE", "logout")) {
+                    resp = logout(req);
+                    ostream.writeObject(resp);
+                    // Just in case it fails to logout somehow.
+                    if (resp.isOk()) {
+                        break;
+                    }
+                }
+
+                if (req.isEndpoint("GET", "sections")) {
+                    resp = viewSections(req);
+                }
+
+                if (resp != null) {
+                    ostream.writeObject(resp);
+                } else {
+                    ostream.writeObject(ServerMsg.asERR(
+                            String.format("Endpoint '%s %s' is not available.", req.getMethod(), req.getResource())));
+                }
+            }
+        } catch (IOException err) {
+            err.printStackTrace();
+        }
+    }
+
+    private ServerMsg logout(ClientMsg req) {
+        return ServerMsg.asOK("logout");
+    }
+
+    private ServerMsg viewSections(ClientMsg req) {
+        return null;
+    }
+}

--- a/src/server/ServerMain.java
+++ b/src/server/ServerMain.java
@@ -10,6 +10,9 @@ import java.util.HashMap;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 
+import objects.Account;
+import objects.Administrator;
+import objects.Student;
 import objects.University;
 
 public class ServerMain {
@@ -20,6 +23,13 @@ public class ServerMain {
             System.out.println(String.format("Listening on %s:%d", localhost.getHostAddress(), 7777));
 
             University[] universities = loadInfoFromFile("unis.txt");
+
+            // Fake setup
+            // TODO: Remove later.
+            for (int i = 0; i < universities.length; ++i) {
+                universities[i].addAdmin(new Administrator("Admin", new Account("admin", "123456")));
+                universities[i].addStudent(new Student("Steve", new Account("steve", "iamsteve")));
+            }
 
             while (true) {
                 Socket socket = ss.accept();
@@ -61,6 +71,6 @@ public class ServerMain {
         } catch (IOException err) {
             err.printStackTrace();
         }
-        return null;
+        return new University[0];
     }
 }

--- a/src/server/ServerMain.java
+++ b/src/server/ServerMain.java
@@ -1,9 +1,16 @@
 package server;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.HashMap;
+import java.util.Scanner;
+import java.util.stream.Collectors;
+
+import objects.University;
 
 public class ServerMain {
     public static void main(String[] args) {
@@ -12,18 +19,48 @@ public class ServerMain {
             InetAddress localhost = InetAddress.getLocalHost();
             System.out.println(String.format("Listening on %s:%d", localhost.getHostAddress(), 7777));
 
-            // TODO: Setup universities
+            University[] universities = loadInfoFromFile("unis.txt");
 
             while (true) {
                 Socket socket = ss.accept();
                 System.out.println("Client connected: " + socket.getInetAddress());
 
-                ClientHandler handler = new ClientHandler(socket);
+                ClientHandler handler = new ClientHandler(socket, universities);
                 new Thread(handler).start();
             }
 
         } catch (IOException err) {
             err.printStackTrace();
         }
+    }
+
+    private static University[] loadInfoFromFile(String filename) throws FileNotFoundException {
+        File file = new File(filename);
+        try (Scanner scanner = new Scanner(file)) {
+            // nextInt() doesn't move the scanner, yay...
+            int num = Integer.valueOf(scanner.nextLine());
+            HashMap<String, University> uniMap = new HashMap<>();
+            for (int i = 0; i < num; ++i) {
+                String row = scanner.nextLine();
+                String[] entry = row.split(",");
+                uniMap.put(entry[0], new University(entry[0], entry[1]));
+
+                // TODO: Additional info for universities can be provided in further columns.
+                // For now it only loads the bare minimum for the constructor.
+                // If for example, we also want to load admin+student info from file as well,
+                // one of the column can specify the filename in which it can get that kind of
+                // info.
+                // So something like "CSUEB,Carlos Bee,csueb_admins.txt,csueb_students.txt"
+            }
+
+            University[] unis = uniMap.values().stream()
+                    .collect(Collectors.toList())
+                    .toArray(new University[0]); // Weird syntax but it works, check the docs
+
+            return unis;
+        } catch (IOException err) {
+            err.printStackTrace();
+        }
+        return null;
     }
 }

--- a/src/server/SessionHandler.java
+++ b/src/server/SessionHandler.java
@@ -1,0 +1,24 @@
+package server;
+
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.Socket;
+
+import objects.University;
+
+public abstract class SessionHandler {
+    protected final Socket socket;
+    protected final ObjectInputStream istream;
+    protected final ObjectOutputStream ostream;
+    protected final University university;
+
+    protected SessionHandler(Socket socket, ObjectInputStream istream, ObjectOutputStream ostream,
+            University university) {
+        this.socket = socket;
+        this.istream = istream;
+        this.ostream = ostream;
+        this.university = university;
+    }
+
+    public abstract void run();
+}

--- a/src/server/StudentSessionHandler.java
+++ b/src/server/StudentSessionHandler.java
@@ -1,0 +1,101 @@
+package server;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.Socket;
+
+import objects.ClientMsg;
+import objects.ServerMsg;
+import objects.Student;
+import objects.University;
+
+public class StudentSessionHandler extends SessionHandler {
+    private Student student;
+
+    public StudentSessionHandler(Socket socket, ObjectInputStream istream, ObjectOutputStream ostream,
+            University university, Student student) {
+        super(socket, istream, ostream, university);
+        this.student = student;
+    }
+
+    @Override
+    public void run() {
+        try {
+            ostream.writeObject(ServerMsg.asOK(student.getID()));
+            while (true) {
+                ClientMsg req = null;
+                ServerMsg resp = null;
+
+                try {
+                    req = (ClientMsg) istream.readObject();
+                } catch (ClassNotFoundException err) {
+                    ostream.writeObject(ServerMsg.asERR("Conversion failed, 'ClientMsg' expected."));
+                    continue;
+                }
+
+                if (req.isEndpoint("CREATE", "logout")) {
+                    resp = logout(req);
+                    ostream.writeObject(resp);
+                    // Just in case it fails to logout somehow.
+                    if (resp.isOk()) {
+                        break;
+                    }
+                }
+
+                if (req.isEndpoint("CREATE", "message")) {
+                    resp = capitalizeMessage(req);
+                } else if (req.isEndpoint("GET", "courses")) {
+                    resp = fetchCourses(req);
+                } else if (req.isEndpoint("GET", "schedule")) {
+                    resp = fetchSchedule(req);
+                } else if (req.isEndpoint("CREATE", "enroll")) {
+                    resp = enroll(req);
+                } else if (req.isEndpoint("CREATE", "drop")) {
+                    resp = drop(req);
+                } else if (req.isEndpoint("GET", "past-enroll")) {
+                    resp = fetchPastEnrollment(req);
+                }
+
+                if (resp != null) {
+                    ostream.writeObject(resp);
+                } else {
+                    ostream.writeObject(ServerMsg.asERR(
+                            String.format("Endpoint '%s %s' is not available.", req.getMethod(), req.getResource())));
+                }
+            }
+        } catch (IOException err) {
+            err.printStackTrace();
+        }
+    }
+
+    // NOTE: Mock service, will delete later.
+    private ServerMsg capitalizeMessage(ClientMsg req) {
+        String message = (String) req.getBody();
+        return ServerMsg.asOK(message.toUpperCase());
+    }
+
+    private ServerMsg logout(ClientMsg req) {
+        return ServerMsg.asOK("logout");
+    }
+
+    private ServerMsg fetchCourses(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg fetchSchedule(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg enroll(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg drop(ClientMsg req) {
+        return null;
+    }
+
+    private ServerMsg fetchPastEnrollment(ClientMsg req) {
+        return null;
+    }
+}

--- a/unis.txt
+++ b/unis.txt
@@ -1,0 +1,3 @@
+2
+CSU East Bay,Somewhere on Earth
+Some other uni,Another place


### PR DESCRIPTION
- Added `Tuple`.
  - This change didn't make it last PR, so it's here :)
- Implemented `ClientHandler.run()`.
  - It will keep listening until the socket is closed.
  - When it receives a client request, it'll check if that's a login request. If it is, it'll check against the credentials to see who is logging in. Once it identifies who, it creates an appropriate session and pass control to that session until the session terminates.
  - After the session terminates, the handler is still active in case the client logs out and logs back in again.
- Implemented the skeleton for all sessions.
  -  Currently, admin and student session has a mock endpoint `CREATE message` that returns a capitalized message sent from the client.
  - All other endpoints aside from `CREATE logout` are not doing anything.

If approved:
- This PR will be squashed before merging (whoever press the merge button pls don't forget this).
- The branch `server_hello` will be deleted.