### PR TITLE
Testing3

### DIFF
--- a/src/objects/Section.java
+++ b/src/objects/Section.java
@@ -141,7 +141,12 @@ public class Section implements Serializable {
     public synchronized SectionStatus getStatus() {
         return status;
     }
-
+    
+  //Testing Purposes
+    public static void resetID() {
+    	_id = 0;
+    }
+    
     public synchronized String getID() {
         return id;
     }

--- a/src/testing/BodyCourseSearchTest.java
+++ b/src/testing/BodyCourseSearchTest.java
@@ -1,0 +1,50 @@
+package testing;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import objects.*;
+
+class BodyCourseSearchTest {
+	
+	private BodyCourseSearch bodyCourseSearch;
+	
+	@BeforeEach
+	void setUp() {
+		bodyCourseSearch = new BodyCourseSearch();
+	}
+	
+	@Test
+	void testConstructor() {
+		assertNotNull(bodyCourseSearch);
+		assertEquals("", bodyCourseSearch.getCourseName());
+		assertEquals("", bodyCourseSearch.getCoursePrefix());
+		assertEquals("", bodyCourseSearch.getCourseNumber());
+		assertEquals("", bodyCourseSearch.getInstructorName());
+	}
+	
+	@Test
+	void testGetAndSetCourseName() {
+		bodyCourseSearch.setCourseName("Software Engineering");
+		assertEquals("Software Engineering", bodyCourseSearch.getCourseName());
+	}
+	
+	@Test
+	void testGetAndSetCoursePrefix() {
+		bodyCourseSearch.setCoursePrefix("CS");
+		assertEquals("CS", bodyCourseSearch.getCoursePrefix());
+	}
+	
+	@Test
+	void testGetAndSetCourseNumber() {
+		bodyCourseSearch.setCourseNumber("401");
+		assertEquals("401", bodyCourseSearch.getCourseNumber());
+	}
+	
+	@Test
+	void testGetAndSetInstructorName() {
+		bodyCourseSearch.setInstructorName("Dr. Smith");
+		assertEquals("Dr. Smith", bodyCourseSearch.getInstructorName());
+	}
+}

--- a/src/testing/BodyEnrollOrDropAsTest.java
+++ b/src/testing/BodyEnrollOrDropAsTest.java
@@ -1,0 +1,54 @@
+package testing;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import objects.*;
+
+class BodyEnrollOrDropAsTest {
+	
+	private BodyEnrollOrDropAs body;
+	private Section section;
+	private String studentID;
+	
+	@BeforeEach
+	void setUp() {
+		studentID = "student1";
+		Course course = new Course("CS", "401", "Software Engineering");
+		Instructor instructor = new Instructor("Dr. Smith", new Account("smith", "pass123"));
+		section = new Section(course, "1", 30, 10, instructor);
+		body = new BodyEnrollOrDropAs(studentID, section);
+	}
+	
+	@Test
+	void testConstructorNull() {
+		Exception exception = assertThrows(NullPointerException.class, () -> {
+			new BodyEnrollOrDropAs(null, section);
+		});
+		assertEquals("Arguments for constructor must not be null.", exception.getMessage());
+		
+		exception = assertThrows(NullPointerException.class, () -> {
+			new BodyEnrollOrDropAs(studentID, null);
+		});
+		assertEquals("Arguments for constructor must not be null.", exception.getMessage());
+	}
+	
+	@Test
+	void testConstructorValid() {
+		assertNotNull(body);
+		assertEquals("student1", body.getStudentID());
+		assertEquals(section, body.getSection());
+	}
+	
+	@Test
+	void testGetStudentID() {
+		assertEquals("student1", body.getStudentID());
+	}
+	
+	@Test
+	void testGetSection() {
+		assertEquals(section, body.getSection());
+	}
+
+}

--- a/src/testing/BodyLoginSuccessTest.java
+++ b/src/testing/BodyLoginSuccessTest.java
@@ -1,0 +1,34 @@
+package testing;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import objects.*;
+import java.io.Serializable;
+
+class BodyLoginSuccessTest {
+
+	@Test
+	void testConstructor() {
+		Serializable client = "NewClient";
+		BodyLoginSuccess bodyLoginSuccess = new BodyLoginSuccess("Admin", client);
+		assertNotNull(bodyLoginSuccess);
+		assertEquals("Admin", bodyLoginSuccess.getRole());
+		assertEquals(client, bodyLoginSuccess.getClient());
+	}
+	
+	@Test 
+	void testGetRole() {
+		Serializable client = "NewClient";
+		BodyLoginSuccess bodyLoginSuccess = new BodyLoginSuccess("Admin", client);
+		assertEquals("Admin", bodyLoginSuccess.getRole());
+	}
+	
+	@Test 
+	void testGetClient() {
+		Serializable client = "NewClient";
+		BodyLoginSuccess bodyLoginSuccess = new BodyLoginSuccess("Admin", client);
+		assertEquals(client, bodyLoginSuccess.getClient());
+	}
+
+}

--- a/src/testing/BodyLoginTest.java
+++ b/src/testing/BodyLoginTest.java
@@ -1,0 +1,61 @@
+package testing;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import objects.*;
+
+class BodyLoginTest {
+
+	@Test
+	void testConstructorValid() {
+		BodyLogin bodyLogin = new BodyLogin("CSU East Bay", "user1", "pass1");
+		assertNotNull(bodyLogin);
+		assertEquals("CSU East Bay", bodyLogin.getUniName());
+		assertEquals("user1", bodyLogin.getLoginID());
+		assertEquals("pass1", bodyLogin.getPassword());
+	}
+	
+	@Test
+	void testConstructorNullUniName() {
+		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+			new BodyLogin(null, "user1", "pass1");
+		});
+		assertEquals("University Name can't be null.", exception.getMessage());
+	}
+	
+	@Test
+	void testConstructorNullLoginID() {
+		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+			new BodyLogin("CSU East Bay", null, "pass1");
+		});
+		assertEquals("Login ID can't be null.", exception.getMessage());
+	}
+	
+	@Test
+	void testConstructorNullPassword() {
+		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+			new BodyLogin("CSU East Bay", "user1", null);
+		});
+		assertEquals("Password can't be null.", exception.getMessage());
+	}
+	
+	@Test
+	void testGetUniName() {
+		BodyLogin bodyLogin = new BodyLogin("CSU East Bay", "user1", "pass1");
+		assertEquals("CSU East Bay", bodyLogin.getUniName());
+	}
+	
+	@Test
+	void testGetLoginID() {
+		BodyLogin bodyLogin = new BodyLogin("CSU East Bay", "user1", "pass1");
+		assertEquals("user1", bodyLogin.getLoginID());
+	}
+	
+	@Test
+	void testPassword() {
+		BodyLogin bodyLogin = new BodyLogin("CSU East Bay", "user1", "pass1");
+		assertEquals("pass1", bodyLogin.getPassword());
+	}
+
+}

--- a/src/testing/CollegeEnrollmentTestSuite.java
+++ b/src/testing/CollegeEnrollmentTestSuite.java
@@ -1,0 +1,33 @@
+package testing;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+import org.junit.jupiter.api.Test;
+
+@Suite
+@SelectClasses({
+	AccountTest.class,
+	AdministratorTest.class,
+	BodyCourseSearchTest.class,
+	BodyEnrollOrDropAsTest.class,
+	BodyLoginSuccessTest.class,
+	BodyLoginTest.class,
+	ClientmsgTest.class,
+	CourseTest.class,
+	InstructorTest.class,
+	ScheduleEntryTest.class,
+	SectionTest.class,
+	ServermsgTest.class,
+	StudentTest.class,
+	TupleTest.class,
+	UniversityTest.class
+})
+
+class CollegeEnrollmentTestSuite {
+	@Test
+	void testAll() {
+		
+	}
+
+}

--- a/src/testing/ScheduleEntryTest.java
+++ b/src/testing/ScheduleEntryTest.java
@@ -59,7 +59,7 @@ class ScheduleEntryTest {
 				
 	}
 	
-	//Test Failing 
+	
 	@Test
 	void testConstructorInvalid() {
 		Exception exception = assertThrows(IllegalArgumentException.class, () -> {
@@ -67,8 +67,8 @@ class ScheduleEntryTest {
 					"location4", 
 					true, 
 					DayOfWeek.WEDNESDAY, 
-					OffsetTime.parse("10:00+00:00"),
-					OffsetTime.parse("09:00+00:00"));
+					OffsetTime.parse("09:00+00:00"),
+					OffsetTime.parse("08:00+00:00"));
 		});
 		assertEquals("'end_time' must be strictly after 'start_time'", exception.getMessage());
 	}

--- a/src/testing/SectionTest.java
+++ b/src/testing/SectionTest.java
@@ -18,6 +18,7 @@ class SectionTest {
 	
 	@BeforeEach
 	void setUp() {
+		Section.resetID();
 		course = new Course("CS", "401", "Software Engineering");
 		instructor = new Instructor("Smith", null);
 		section = new Section(course, "1", 30, 10, instructor);
@@ -144,7 +145,7 @@ class SectionTest {
 	
 	@Test
 	void testGetID() {
-		assertEquals("section_7", section.getID());
+		assertEquals("section_0", section.getID());
 	}
 	
 	@Test 


### PR DESCRIPTION
Updates: 
ScheduleEntryTest: Switched the times to check for IllegalArgumentException throwing 
SectionTest: sectionID being returned was different from the sectionID being returned when running the Test Suite 
Section Class: Added a function to reset the sectionID back to 0 for test purposes 

Added: 
BodyCourseSearchTest: All Passed
BodyEnrollOrDropAsTest: All Passed
BodyLoginSuccessTest: All Passed
BodyLoginTest: All Passed
CollegeEnrollmentTestSuite: All Passed
